### PR TITLE
Fix failure for `get_total_result_of_rspec_html`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Fixes
+
+* Fix failure for `get_total_result_of_rspec_html`
+  on empty string param
+
 ## 0.1.0 (2020-03-20)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-* Fix failure for `get_total_result_of_rspec_html`
+* Fix failure for `get_total_result_of_rspec_html`,
+  `get_failed_cases_count_from_html`  
   on empty string param
 
 ## 0.1.0 (2020-03-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 * Fix failure for `get_total_result_of_rspec_html`,
-  `get_failed_cases_count_from_html`  
+  `get_failed_cases_count_from_html` 
   on empty string param
 
 ## 0.1.0 (2020-03-20)

--- a/lib/onlyoffice_rspec_result_parser/rspec_result_parser.rb
+++ b/lib/onlyoffice_rspec_result_parser/rspec_result_parser.rb
@@ -32,6 +32,8 @@ module OnlyofficeRspecResultParser
       alias parse_rspec_html_string parse_rspec_html
 
       def get_failed_cases_count_from_html(html_path)
+        return 0 if html_path.empty?
+
         page = Nokogiri::HTML(read_file(html_path))
         RspecResult.new.parse_page(page, true).failed_count
       end

--- a/lib/onlyoffice_rspec_result_parser/rspec_result_parser.rb
+++ b/lib/onlyoffice_rspec_result_parser/rspec_result_parser.rb
@@ -37,6 +37,8 @@ module OnlyofficeRspecResultParser
       end
 
       def get_total_result_of_rspec_html(html_path)
+        return html_path if html_path.empty?
+
         page = Nokogiri::HTML(read_file(html_path))
         RspecResult.new.parse_page(page, true).total
       end

--- a/spec/onlyoffice_rspec_result_parser/result_parser_get_failed_cases_count_from_html_spec.rb
+++ b/spec/onlyoffice_rspec_result_parser/result_parser_get_failed_cases_count_from_html_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OnlyofficeRspecResultParser::ResultParser,
+         '.get_failed_cases_count_from_html' do
+  it 'get_failed_cases_count_from_html return zero for empty string' do
+    expect(described_class.get_failed_cases_count_from_html('')).to eq(0)
+  end
+end

--- a/spec/onlyoffice_rspec_result_parser/result_parser_get_total_result_of_rspec_html_spec.rb
+++ b/spec/onlyoffice_rspec_result_parser/result_parser_get_total_result_of_rspec_html_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OnlyofficeRspecResultParser::ResultParser,
+         '.get_total_result_of_rspec_html' do
+  it 'get_total_result_of_rspec_html return empty string for empty string' do
+    expect(described_class.get_total_result_of_rspec_html('')).to eq('')
+  end
+end


### PR DESCRIPTION
on empty string param